### PR TITLE
mobile menu disabled clicks, split components

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,6 +69,17 @@ hr {
   margin: 0;
 }
 
+.mobile__background-blur {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(145, 145, 145, 0.4);
+  z-index: -1;
+}
 @media all and (min-width: 800px) {
   .menu__icon {
     display: none !important;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Countdown from "react-countdown";
-import { Button, CircularProgress, Snackbar, AppBar, Toolbar, Typography, Link, Container, Grid, Card } from "@material-ui/core";
+import { Button, CircularProgress, Snackbar, AppBar, Toolbar, Typography, Link, Container, Grid } from "@material-ui/core";
 import MenuIcon from '@material-ui/icons/Menu';
 import Alert from "@material-ui/lab/Alert";
-import Ticker from "react-ticker";
 
 import * as anchor from "@project-serum/anchor";
 
@@ -20,6 +19,10 @@ import {
   mintOneToken,
   shortenAddress,
 } from "./candy-machine";
+
+import MonkeyDescription from "./components/homePage/MonkeyDescription";
+import MonkeyAttributes from "./components/homePage/MonkeyAttributes";
+import MonkeyTicker from "./components/homePage/MonkeyTicker";
 
 const CounterText = styled.span``; // add your styles here
 
@@ -85,6 +88,7 @@ const Home = (props: HomeProps) => {
   const [toggleMenu, setToggleMenu] = useState(false);
 
   const preventDefault = (event: React.SyntheticEvent) => event.preventDefault();
+  
   const refreshCandyMachineState = () => {
     (async () => {
       if (!wallet) return;
@@ -193,6 +197,11 @@ const Home = (props: HomeProps) => {
     props.connection,
   ]);
 
+  function mobileMenuToggle() {
+    setToggleMenu(!toggleMenu)
+    document.body.classList.toggle("freeze");
+  }
+
   return (
     <main>
       <Snackbar
@@ -207,14 +216,19 @@ const Home = (props: HomeProps) => {
           {alertState.message}
         </Alert> 
       </Snackbar>
-
+      
       <AppBarStyled position="static">
         <ToolbarStyled style={{ position: "relative"}}>
           <div style={{ display: "flex", alignItems: "center" }}>
             <img style={{ height: "50px", marginRight: "15px" }} src="/assets/img/MOTBLogo.png" alt="MOTB Logo" />
             <h1 style={{ display: "inline-block", background: "none", WebkitTextFillColor: "#444" }}>MOTB</h1>
           </div>
-          <MenuIcon className="menu__icon" onClick={() => setToggleMenu(!toggleMenu)}/>
+          <MenuIcon className="menu__icon" onClick={mobileMenuToggle}/>
+          {
+            toggleMenu ?
+            <div className="mobile__background-blur"></div>
+            : null
+          }
           <div className={`menu ${toggleMenu ? 'show' : ''}`}>
           <Typography>
             <LinkStyled href="#" onClick={preventDefault}>
@@ -277,22 +291,7 @@ const Home = (props: HomeProps) => {
         </Typography>
       </Container>
 
-      <Ticker>
-          {() => (
-              <div style={{ height: "200px", width: "max-content", margin: "40px 0px" }}>
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk0t.png" alt="Monkey #0" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk1t.png" alt="Monkey #1" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk2t.png" alt="Monkey #2" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk3t.png" alt="Monkey #3" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk4t.png" alt="Monkey #4" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk5t.png" alt="Monkey #5" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk6t.png" alt="Monkey #6" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk7t.png" alt="Monkey #7" />
-                  <img style={{ width: 200, marginRight: "10px" }} src="assets/img/mk8t.png" alt="Monkey #8" />
-              </div>
-          )}
-      </Ticker>
-
+      <MonkeyTicker />
       <hr />
 
       <Container maxWidth="md" style={{ textAlign: "center", margin: "40px auto" }}>
@@ -397,80 +396,11 @@ const Home = (props: HomeProps) => {
           </Grid>
         
       </Container>
-<hr />
-      <Grid container direction="column" justifyContent="center" alignItems="center" style={{ padding: "4em", maxWidth: "1200px", margin: "0 auto" }}>
-              <Grid container item direction="column" alignItems="center" style={{ maxWidth: "400px", paddingBottom: "2em"}}>
-                  <div style={{ width: "100px", height: "3px", backgroundColor: "grey", textAlign: "center"}}></div>
-                  <Typography style={{ fontWeight: "bold", fontSize: "2rem", lineHeight: "2.5rem", paddingTop: "1em", textAlign: "center" }} variant="body1" gutterBottom>
-                    This is what you get when buying a Monkey on the Block NFT
-                  </Typography> 
-                  <Typography style={{ fontSize: "1rem", textAlign: "center" }} variant="body2" gutterBottom>
-                    Do you see any Teletubbies in here? Do you see a slender plastic tag clipped to my shirt with my name printed on it?
-                    <br />
-                    <br />
-                    Best NFT you will ever buy!
-                  </Typography>
-              </Grid>
-              
-              <Grid
-                container
-                item
-                direction="row"
-                justifyContent="center"
-                alignItems="stretch"
-                style={{gap: '1em'}}
-              >
-                <Grid item md={3} xs={12} style={{ backgroundColor: '#fff', padding: '3em', boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)", display: "flex", flexDirection: "column", justifyContent: 'flex-end', borderRadius: '15px', maxWidth: '400px'}}>
-                  <Typography style={{ fontWeight: "bold", textAlign: "center" }} component="h2" variant="h5" gutterBottom>RARITY</Typography>
-                  <Typography style={{ color: 'black', fontSize: '0.8rem'}} variant="body2" gutterBottom>
-                    Each MOTB has its own rarity to it. You can find monkeys from being super rare to very common. The Rarity of each monkey depends on the attributes and pieces it consists of.
-                  </Typography>
-                </Grid>
-
-                <Grid item md={3} xs={12} style={{ backgroundColor: '#fff', padding: '3em', boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)", borderRadius: '15px', maxWidth: '400px'}}>
-                  <Typography style={{ fontWeight: "bold", textAlign: "center" }} component="h2" variant="h5" gutterBottom>120 UNIQUE ATTRIBUTES</Typography>
-                  <Typography style={{ color: 'black', fontSize: '0.8rem'}} variant="body2" gutterBottom>
-                    Each MOTB has its own rarity to it. You can find monkeys from being super rare to very common. The Rarity of each monkey depends on the attributes and pieces it consists of.
-                  </Typography>
-                </Grid>
-
-                <Grid item md={3} xs={12} style={{ backgroundColor: '#fff', padding: '3em', boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)", borderRadius: '15px', maxWidth: '400px'}}>
-                  <Typography style={{ fontWeight: "bold", textAlign: "center" }} component="h2" variant="h5" gutterBottom>PROOF OF OWNERSHIP</Typography>
-                  <Typography style={{ color: 'black', fontSize: '0.8rem'}} variant="body2" gutterBottom>
-                    Each MOTB has its own rarity to it. You can find monkeys from being super rare to very common. The Rarity of each monkey depends on the attributes and pieces it consists of.
-                  </Typography>
-                </Grid>
-                
-              </Grid>
-        </Grid>
       <hr />
-
-      <Container maxWidth="md" style={{ textAlign: "center", margin: "40px auto", padding: "4em" }}>
-            <img src="/assets/temp-img/all-cards.png" alt="Five Monkey cards" style={{ maxWidth: "100%", height: "auto"}}/>
-            <Grid 
-              container 
-              direction="row"
-              justifyContent="center"
-              alignItems="center"
-              spacing={6}
-              style={{ paddingTop: "4em"}}
-            >
-              <Grid item xs={12} md={4} style={{ backgroundColor: '#fff', padding: '3em', boxShadow: "0 8px 40px -12px rgba(0,0,0,0.3)", borderRadius: "15px", maxWidth: '400px'}}>
-    
-                  <Typography style={{ fontWeight: "bold" }} component="h2" variant="h5" gutterBottom>
-                    ATTRIBUTES
-                  </Typography>
-                  <Typography style={{ color: 'black', fontSize: '0.8rem', textAlign: "left"}} variant="body2" gutterBottom>
-                    Each MOTB has its own rarity to it. You can find monkeys from being super rare to very common. The Rarity of each monkey depends on the attributes and pieces it consists of.
-                  </Typography>
-            
-              </Grid>
-
-              <Grid item xs={12} md={8}>
-                <img src="/assets/temp-img/attributes.png" alt="Five Monkey cards" style={{ maxWidth: "100%", height: "auto"}}/>
-              </Grid> 
-            </Grid>
-      </Container>
+          <MonkeyDescription />
+      <hr />
+          <MonkeyAttributes />
+      
     </main>
   );
 };

--- a/src/components/homePage/MonkeyAttributes.jsx
+++ b/src/components/homePage/MonkeyAttributes.jsx
@@ -1,0 +1,65 @@
+import { Container, Grid, Typography } from "@material-ui/core";
+
+const MonkeyAttributes = (props) => {
+  return (
+    <Container
+      maxWidth="md"
+      style={{ textAlign: "center", margin: "40px auto", padding: "4em" }}
+    >
+      <img
+        src="/assets/temp-img/all-cards.png"
+        alt="Five Monkey cards"
+        style={{ maxWidth: "100%", height: "auto" }}
+      />
+      <Grid
+        container
+        direction="row"
+        justifyContent="center"
+        alignItems="center"
+        spacing={6}
+        style={{ paddingTop: "4em" }}
+      >
+        <Grid
+          item
+          xs={12}
+          md={4}
+          style={{
+            backgroundColor: "#fff",
+            padding: "3em",
+            boxShadow: "0 8px 40px -12px rgba(0,0,0,0.3)",
+            borderRadius: "15px",
+            maxWidth: "400px",
+          }}
+        >
+          <Typography
+            style={{ fontWeight: "bold" }}
+            component="h2"
+            variant="h5"
+            gutterBottom
+          >
+            ATTRIBUTES
+          </Typography>
+          <Typography
+            style={{ color: "black", fontSize: "0.8rem", textAlign: "left" }}
+            variant="body2"
+            gutterBottom
+          >
+            Each MOTB has its own rarity to it. You can find monkeys from being
+            super rare to very common. The Rarity of each monkey depends on the
+            attributes and pieces it consists of.
+          </Typography>
+        </Grid>
+
+        <Grid item xs={12} md={8}>
+          <img
+            src="/assets/temp-img/attributes.png"
+            alt="Five Monkey cards"
+            style={{ maxWidth: "100%", height: "auto" }}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MonkeyAttributes;

--- a/src/components/homePage/MonkeyDescription.jsx
+++ b/src/components/homePage/MonkeyDescription.jsx
@@ -1,0 +1,161 @@
+import { Typography, Grid } from "@material-ui/core";
+
+const MonkeyDescription = (props) => {
+  return (
+    <Grid
+      container
+      direction="column"
+      justifyContent="center"
+      alignItems="center"
+      style={{ padding: "4em", maxWidth: "1200px", margin: "0 auto" }}
+    >
+      <Grid
+        container
+        item
+        direction="column"
+        alignItems="center"
+        style={{ maxWidth: "400px", paddingBottom: "2em" }}
+      >
+        <div
+          style={{
+            width: "100px",
+            height: "3px",
+            backgroundColor: "grey",
+            textAlign: "center",
+          }}
+        ></div>
+        <Typography
+          style={{
+            fontWeight: "bold",
+            fontSize: "2rem",
+            lineHeight: "2.5rem",
+            paddingTop: "1em",
+            textAlign: "center",
+          }}
+          variant="body1"
+          gutterBottom
+        >
+          This is what you get when buying a Monkey on the Block NFT
+        </Typography>
+        <Typography
+          style={{ fontSize: "1rem", textAlign: "center" }}
+          variant="body2"
+          gutterBottom
+        >
+          Do you see any Teletubbies in here? Do you see a slender plastic tag
+          clipped to my shirt with my name printed on it?
+          <br />
+          <br />
+          Best NFT you will ever buy!
+        </Typography>
+      </Grid>
+
+      <Grid
+        container
+        item
+        direction="row"
+        justifyContent="center"
+        alignItems="stretch"
+        style={{ gap: "1em" }}
+      >
+        <Grid
+          item
+          md={3}
+          xs={12}
+          style={{
+            backgroundColor: "#fff",
+            padding: "3em",
+            boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-end",
+            borderRadius: "15px",
+            maxWidth: "400px",
+          }}
+        >
+          <Typography
+            style={{ fontWeight: "bold", textAlign: "center" }}
+            component="h2"
+            variant="h5"
+            gutterBottom
+          >
+            RARITY
+          </Typography>
+          <Typography
+            style={{ color: "black", fontSize: "0.8rem" }}
+            variant="body2"
+            gutterBottom
+          >
+            Each MOTB has its own rarity to it. You can find monkeys from being
+            super rare to very common. The Rarity of each monkey depends on the
+            attributes and pieces it consists of.
+          </Typography>
+        </Grid>
+
+        <Grid
+          item
+          md={3}
+          xs={12}
+          style={{
+            backgroundColor: "#fff",
+            padding: "3em",
+            boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)",
+            borderRadius: "15px",
+            maxWidth: "400px",
+          }}
+        >
+          <Typography
+            style={{ fontWeight: "bold", textAlign: "center" }}
+            component="h2"
+            variant="h5"
+            gutterBottom
+          >
+            120 UNIQUE ATTRIBUTES
+          </Typography>
+          <Typography
+            style={{ color: "black", fontSize: "0.8rem" }}
+            variant="body2"
+            gutterBottom
+          >
+            Each MOTB has its own rarity to it. You can find monkeys from being
+            super rare to very common. The Rarity of each monkey depends on the
+            attributes and pieces it consists of.
+          </Typography>
+        </Grid>
+
+        <Grid
+          item
+          md={3}
+          xs={12}
+          style={{
+            backgroundColor: "#fff",
+            padding: "3em",
+            boxShadow: "0 8px 40px -12px rgba(0,0,0,0.1)",
+            borderRadius: "15px",
+            maxWidth: "400px",
+          }}
+        >
+          <Typography
+            style={{ fontWeight: "bold", textAlign: "center" }}
+            component="h2"
+            variant="h5"
+            gutterBottom
+          >
+            PROOF OF OWNERSHIP
+          </Typography>
+          <Typography
+            style={{ color: "black", fontSize: "0.8rem" }}
+            variant="body2"
+            gutterBottom
+          >
+            Each MOTB has its own rarity to it. You can find monkeys from being
+            super rare to very common. The Rarity of each monkey depends on the
+            attributes and pieces it consists of.
+          </Typography>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default MonkeyDescription;

--- a/src/components/homePage/MonkeyTicker.jsx
+++ b/src/components/homePage/MonkeyTicker.jsx
@@ -1,0 +1,61 @@
+import Ticker from "react-ticker";
+
+const MonkeyTicker = (props) => {
+  return (
+    <Ticker>
+      {() => (
+        <div
+          style={{ height: "200px", width: "max-content", margin: "40px 0px" }}
+        >
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk0t.png"
+            alt="Monkey #0"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk1t.png"
+            alt="Monkey #1"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk2t.png"
+            alt="Monkey #2"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk3t.png"
+            alt="Monkey #3"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk4t.png"
+            alt="Monkey #4"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk5t.png"
+            alt="Monkey #5"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk6t.png"
+            alt="Monkey #6"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk7t.png"
+            alt="Monkey #7"
+          />
+          <img
+            style={{ width: 200, marginRight: "10px" }}
+            src="assets/img/mk8t.png"
+            alt="Monkey #8"
+          />
+        </div>
+      )}
+    </Ticker>
+  );
+};
+
+export default MonkeyTicker;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
@@ -7,6 +11,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: #fff;
   color: #222;
+  overflow-x: hidden;
+}
+
+body.freeze {
+  overflow: hidden;
 }
 
 code {


### PR DESCRIPTION
# Description

Mobile menu finished for basic features: disabled scroll when menu is open and added background blur on the rest of the page.
Split components into their own files to make Home.jsx smaller. Display only components are in the homePage folder.

## Type of change

Please delete options that are not relevant.

- [X] Revision of feature
- [X] Split code

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Developer Tools
- [ ] Cypress
- [ ] CI
